### PR TITLE
Button textinput style

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -1,6 +1,6 @@
 <template lang="pug">
 .flex.flex-col.min-h-screen.font-utd
     CometHeader.sticky.top-0
-    NuxtPage.grow
+    NuxtPage.mx-5.sm_mx-24.grow
     CometFooter
 </template>

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -17,11 +17,27 @@
 
     /* button styling */
     .button {
-    
+        height: 50px;
+        text-align: center;
+        font-family: theme('fontFamily.utd');
+        font-size: x-large;
+        font-weight: 700;
+        border-radius: 15px;
+        /* horizontal, vertical, blur, grow, color */
+        box-shadow: 0px 5px 13px 1px gray;
     }
 
     /* text input styling */
     .input {
-
+        height: 50px;
+        text-indent: 7px;
+        text-align: left;
+        font-family: theme('fontFamily.utd');
+        font-size: x-large;
+        font-weight: 500;eight: 50px;
+        background-color: transparent;
+        border-bottom-style: solid;
+        border-bottom-width: 2px;
+        border-bottom-color: black;
     }
 }

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -24,7 +24,7 @@
         font-weight: 700;
         border-radius: 15px;
         /* horizontal, vertical, blur, grow, color */
-        box-shadow: 0px 5px 13px 1px gray;
+        box-shadow: 0px 4px 5px 1px rgb(185,185,185);
     }
 
     /* text input styling */
@@ -36,8 +36,9 @@
         font-size: x-large;
         font-weight: 400;eight: 50px;
         background-color: transparent;
+        outline: none;
         border-bottom-style: solid;
         border-bottom-width: 1px;
-        border-bottom-color: black;
+        border-bottom-color: rgb(100,100,100);
     }
 }

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -34,10 +34,10 @@
         text-align: left;
         font-family: theme('fontFamily.utd');
         font-size: x-large;
-        font-weight: 500;eight: 50px;
+        font-weight: 400;eight: 50px;
         background-color: transparent;
         border-bottom-style: solid;
-        border-bottom-width: 2px;
+        border-bottom-width: 1px;
         border-bottom-color: black;
     }
 }


### PR DESCRIPTION
Check out the styling. I think it's pretty close, but I've also tried to keep it pretty minimal. The tailwind docs recommend not creating too many special classes or you might as well just use basic css.

example implementation:

button.button.px-14.bg-utd-orange.text-white
        | Source
input.input

![Firefox_Screenshot_2024-10-06T05-00-00 262Z](https://github.com/user-attachments/assets/7973d164-76d7-4ba4-94f6-e3c43c109bc6)
