### PR TITLE
Replaced conformation popup with terms and cond.

### DIFF
--- a/components/CartView.vue
+++ b/components/CartView.vue
@@ -30,7 +30,7 @@ div.w-full.sm_w-80.drop-shadow-standard.bg-white.flex.flex-col.text-xl
 			div(class="h-[1px]").bg-black
 
 			button(v-if="pending" @click="emit('openPendingModal')").bg-utd-green.text-white.w-full.button Pending Cart...
-			button(v-else @click="submitCart").button.bg-utd-green.text-white.w-full Submit Cart
+			button(v-else @click="emit('openPendingModal')").button.bg-utd-green.text-white.w-full Submit Cart
 </template>
 
 <script setup lang="ts">
@@ -43,6 +43,7 @@ const { resetCartView, getCart } = store
 const { cartItems, cartTotalCount, cartAdjustedCount, pending } = storeToRefs(store)
 
 const emit = defineEmits(["openPendingModal"])
+const props = defineProps<{ state: string }>()
 
 const markExpiredItems = ref(false)
 
@@ -57,13 +58,19 @@ const toggleMarkExpiredItems = async () => {
 	}
 }
 
+watch(() => props.state, (newState) => {
+	if (newState === "PENDING") {
+		submitCart()
+	}
+})
+
 const submitCart = async () => {
 	await $fetch("/api/verification/cartRequestVerification", { method: "POST" })
 	await getCart()
-	emit("openPendingModal")
 }
 
 onMounted(async () => {
 	await getCart()
 })
+
 </script>

--- a/components/CartView.vue
+++ b/components/CartView.vue
@@ -29,8 +29,8 @@ div.w-full.sm_w-80.drop-shadow-standard.bg-white.flex.flex-col.text-xl
 				p.ml-2.text-nowrap.hover_underline Mark Expired Items
 			div(class="h-[1px]").bg-black
 
-			button(v-if="pending" @click="emit('openPendingModal')").bg-utd-green.text-white.w-full.button Pending Cart...
-			button(v-else @click="emit('openPendingModal')").button.bg-utd-green.text-white.w-full Submit Cart
+			button(v-if="pending" @click="emit('retractCart')").bg-utd-green.text-white.w-full.button Pending Cart...
+			button(v-else @click="emit('submitCart')").button.bg-utd-green.text-white.w-full Submit Cart
 </template>
 
 <script setup lang="ts">
@@ -42,8 +42,7 @@ const store = useCartStore()
 const { resetCartView, getCart } = store
 const { cartItems, cartTotalCount, cartAdjustedCount, pending } = storeToRefs(store)
 
-const emit = defineEmits(["openPendingModal"])
-const props = defineProps<{ state: string }>()
+const emit = defineEmits(["submitCart", "retractCart"])
 
 const markExpiredItems = ref(false)
 
@@ -51,26 +50,14 @@ const toggleMarkExpiredItems = async () => {
 	markExpiredItems.value = !markExpiredItems.value
 	// reset all expired counts to 0 because we want users to clearly know if they are marking expired items in cart
 	if (!markExpiredItems.value) {
-		cartItems.forEach((cartItem) => {
+		cartItems.value.forEach((cartItem) => {
 			$fetch("/api/cart/cartItem", { method: "POST", body: { itemID: cartItem.itemID, incrementChange: 0, expiredCount: 0 } })
 		})
 		await getCart()
 	}
 }
 
-watch(() => props.state, (newState) => {
-	if (newState === "PENDING") {
-		submitCart()
-	}
-})
-
-const submitCart = async () => {
-	await $fetch("/api/verification/cartRequestVerification", { method: "POST" })
-	await getCart()
-}
-
 onMounted(async () => {
 	await getCart()
 })
-
 </script>

--- a/components/StatementOfUnderstanding.vue
+++ b/components/StatementOfUnderstanding.vue
@@ -1,0 +1,20 @@
+<template lang="pug">
+div.flex.flex-col.pt-2.pb-5.px-5.overflow-y-auto.overscroll-contain
+	p.text-2xl.font-bold.text-center.mb-5
+		| Statement of Understanding
+	p.text-xl.text-center
+		| I assume any and all risks associated with consuming the items I have selected from the Comet Cupboard. I agree to release UT Dallas from liability if I sustain any health or medical issues as a result of consuming foods taken from the Comet Cupboard. I understand that the Comet Cupboard distributes products that may contain nuts or have been processed in plants that use peanuts and/or tree nuts. I also understand that some of Comet Cupboard items may conflict with my allergies or dietary restrictions.
+	p.text-2xl.font-bold.text-center.mb-5.pt-5
+		| Non-Discrimination Clause
+	p.text-xl.text-center
+		| UTD Comet Cupboard does not and shall not discriminate on the basis of race, color, religion (creed), gender, gender expression, age, national origin (ancestry), disability, marital status, sexual orientation, or military status, in any of its activities or operations.
+	div.flex.flex-row.justify-end.space-x-5.pt-7
+		button(@click="emit('cancel')").modal-button.w-40.bg-red-negative.text-white
+			| Disagree
+		button(@click="emit('accept')").modal-button.w-40.bg-utd-green.text-white
+			| Yes, I Agree
+</template>
+
+<script lang="ts" setup>
+const emit = defineEmits(["cancel", "accept"])
+</script>

--- a/pages/inventory-management.vue
+++ b/pages/inventory-management.vue
@@ -42,7 +42,7 @@ div
 							:name="item.name"
 						)
 					// submit button
-					div.sticky.bottom-8.z-20.flex.justify-end.pointer-events-none
+					div.sticky.bottom-8.z-20.flex.justify-end.pointer-events-none.space-x-2
 						button(v-if="JSON.stringify(inventoryCountChanges) === '{}'").button.bg-red-negative.text-white.w-full.sm_w-72.cursor-not-allowed.pointer-events-auto No Changes
 						button(v-else @click="currentModal = ModalType.REVIEW").button.bg-utd-green.text-white.w-full.sm_w-72.pointer-events-auto Review Changes
 						button(class="w-[50px]" @click="scrollToTop").button.bg-utd-green.text-white.drop-shadow-standard.pointer-events-auto

--- a/pages/shopping.vue
+++ b/pages/shopping.vue
@@ -24,17 +24,10 @@ div
 					button(class="w-[50px]" @click="scrollToTop").button.bg-utd-green.text-white.drop-shadow-standard.pointer-events-auto
 						ChevronUpIcon.m-auto.h-6.fill-white.stroke-white
 				TransitionsSlideLeft
-					CartView(v-if="cartView" @openPendingModal="currentModal = ModalType.PENDING").fixed.z-50.right-0.top-20.bottom-0
-				// Pending Review Pop-Up
-				Modal(v-if="currentModal == ModalType.PENDING" title="Pending Review" @toggleModal="closeModal")
-					div.flex.flex-col.p-5
-						div.text-xl.h-20
-							| Your cart has been submitted, please take it to a volunteer for review.
-						div.flex.flex-row.mt-auto
-							button(@click="retractCart").modal-button.bg-utd-orange.text-white.ml-auto.w-full.sm_w-32.mr-5
-								| Edit Cart
-							button(@click="closeModal").modal-button.bg-utd-green.text-white.w-full.sm_w-32
-								| Close
+					CartView(v-if="cartView" @openPendingModal="currentModal = ModalType.ACCEPTING").fixed.z-50.right-0.top-20.bottom-0
+				// Forces the Statement of understanding to be accepted before review can begin
+				Modal(v-if="currentModal == ModalType.ACCEPTING" title="Agreement and Terms" @toggleModal="() => { closeModal(), retractCart() }")
+					StatementOfUnderstanding(@accept="currentModal = ModalType.PENDING" @cancel="() => { closeModal(), retractCart() }")
 
 				// Rejected Pop-Up
 				Modal(v-if="currentModal == ModalType.REJECTED" title="Cart Rejected" @toggleModal="closeModal")
@@ -80,6 +73,7 @@ div
 </template>
 
 <script lang="ts" setup>
+
 import { ChevronUpIcon } from "@heroicons/vue/24/solid"
 import { useCartStore } from "~/stores/cart"
 
@@ -94,6 +88,7 @@ const verificationUpdate = ref<EventSource>()
 
 const ModalType = Object.freeze({
 	PENDING: "PENDING",
+	ACCEPTING: "ACCEPTING", //For statement of understanding
 	ACCEPTED: "ACCEPTED",
 	REJECTED: "REJECTED",
 })

--- a/pages/shopping.vue
+++ b/pages/shopping.vue
@@ -24,10 +24,10 @@ div
 					button(class="w-[50px]" @click="scrollToTop").button.bg-utd-green.text-white.drop-shadow-standard.pointer-events-auto
 						ChevronUpIcon.m-auto.h-6.fill-white.stroke-white
 				TransitionsSlideLeft
-					CartView(v-if="cartView" @openPendingModal="currentModal = ModalType.ACCEPTING").fixed.z-50.right-0.top-20.bottom-0
+					CartView(v-if="cartView" @openPendingModal="currentModal = ModalType.ACCEPTING" :state="currentModal").fixed.z-50.right-0.top-20.bottom-0
 				// Forces the Statement of understanding to be accepted before review can begin
-				Modal(v-if="currentModal == ModalType.ACCEPTING" title="Agreement and Terms" @toggleModal="() => { closeModal(), retractCart() }")
-					StatementOfUnderstanding(@accept="currentModal = ModalType.PENDING" @cancel="() => { closeModal(), retractCart() }")
+				Modal(v-if="currentModal == ModalType.ACCEPTING" title="Agreement and Terms" @toggleModal="() => { closeModal(), resetCartView() }")
+					StatementOfUnderstanding(@accept="currentModal = ModalType.PENDING" @cancel="() => { closeModal(), resetCartView() }")
 
 				// Rejected Pop-Up
 				Modal(v-if="currentModal == ModalType.REJECTED" title="Cart Rejected" @toggleModal="closeModal")
@@ -73,7 +73,6 @@ div
 </template>
 
 <script lang="ts" setup>
-
 import { ChevronUpIcon } from "@heroicons/vue/24/solid"
 import { useCartStore } from "~/stores/cart"
 

--- a/pages/shopping.vue
+++ b/pages/shopping.vue
@@ -24,10 +24,15 @@ div
 					button(class="w-[50px]" @click="scrollToTop").button.bg-utd-green.text-white.drop-shadow-standard.pointer-events-auto
 						ChevronUpIcon.m-auto.h-6.fill-white.stroke-white
 				TransitionsSlideLeft
-					CartView(v-if="cartView" @openPendingModal="currentModal = ModalType.ACCEPTING" :state="currentModal").fixed.z-50.right-0.top-20.bottom-0
+					CartView(
+						v-if="cartView"
+						@retractCart="retractCart"
+						@submitCart="currentModal = ModalType.ACCEPTING"
+						:state="currentModal"
+					).fixed.z-50.right-0.top-20.bottom-0
 				// Forces the Statement of understanding to be accepted before review can begin
 				Modal(v-if="currentModal == ModalType.ACCEPTING" title="Agreement and Terms" @toggleModal="() => { closeModal(), resetCartView() }")
-					StatementOfUnderstanding(@accept="currentModal = ModalType.PENDING" @cancel="() => { closeModal(), resetCartView() }")
+					StatementOfUnderstanding(@accept="submitCart" @cancel="() => { closeModal(), resetCartView() }")
 
 				// Rejected Pop-Up
 				Modal(v-if="currentModal == ModalType.REJECTED" title="Cart Rejected" @toggleModal="closeModal")
@@ -140,6 +145,12 @@ const filteredCategoryItems = computed(() => {
 
 const closeModal = () => {
 	currentModal.value = ""
+}
+
+const submitCart = async () => {
+	await $fetch("/api/verification/cartRequestVerification", { method: "POST" })
+	await getCart()
+	closeModal()
 }
 
 const retractCart = async () => {


### PR DESCRIPTION
Replaced the conformation popup after making a cart that prompted for confirmation or edits with the Statement Of Understanding Functionally the same, but uses comment cupboard's Statement of Understanding component instead of a custom popup. I also added a space in the inventory management page between the review change and to top button to make it look better.

The modal with the Statement of understanding:
![image](https://github.com/user-attachments/assets/c5bf3b1b-202d-42c5-ad1c-de882e80b97d)

To get to the button, one needs to scroll down. My reasoning for the buttons being at the bottom is so that they need to read (or at least pretend to read) the entire clause. Additionally, it is not that much text.

![image](https://github.com/user-attachments/assets/b5facbb8-1511-4050-ac9a-5d83316baede)

Selecting the disagree of the x on the top of the modal will cancel the verification of the cart and close the cart to allow for editing or the logout of the user. 


The inventory management screen had the buttons touch to looking like this:
![image](https://github.com/user-attachments/assets/3930f178-e2e1-4d73-908b-8dbddfeec4f8)
