### PR TITLE
Carts with no items cannot be submitted

### DIFF
--- a/components/CartView.vue
+++ b/components/CartView.vue
@@ -29,7 +29,7 @@ div.w-full.sm_w-80.drop-shadow-standard.bg-white.flex.flex-col.text-xl
 				p.ml-2.text-nowrap.hover_underline Mark Expired Items
 			div(class="h-[1px]").bg-black
 
-			button(v-if="cartTotalCount === 0" disabled).bg-red-negative.text-white.w-full.h-12 Enter Items to Cart
+			button(v-if="cartTotalCount === 0" disabled).bg-cupboard-dg.text-white.w-full.h-12 Enter Items to Cart
 			button(v-else-if="pending" @click="emit('retractCart')").bg-utd-green.text-white.w-full.h-12 Pending Cart...
 			button(v-else @click="emit('submitCart')").bg-utd-green.text-white.w-full.h-12 Submit Cart
 </template>

--- a/components/CartView.vue
+++ b/components/CartView.vue
@@ -29,7 +29,8 @@ div.w-full.sm_w-80.drop-shadow-standard.bg-white.flex.flex-col.text-xl
 				p.ml-2.text-nowrap.hover_underline Mark Expired Items
 			div(class="h-[1px]").bg-black
 
-			button(v-if="pending" @click="emit('retractCart')").bg-utd-green.text-white.w-full.h-12 Pending Cart...
+			button(v-if="cartTotalCount === 0" disabled).bg-red-negative.text-white.w-full.h-12 Enter Items to Cart
+			button(v-else-if="pending" @click="emit('retractCart')").bg-utd-green.text-white.w-full.h-12 Pending Cart...
 			button(v-else @click="emit('submitCart')").bg-utd-green.text-white.w-full.h-12 Submit Cart
 </template>
 

--- a/components/InventoryReviewChanges.vue
+++ b/components/InventoryReviewChanges.vue
@@ -13,7 +13,7 @@ div.flex.flex-col.pt-2.pb-5.px-5.overflow-y-auto.overscroll-contain
 	div.flex.flex-row.justify-end.space-x-5
 		button(@click="emit('cancel')").modal-button.w-40.bg-cupboard-dg.text-white
 			| Cancel
-		button(v-if="source === ''" disabled).modal-button.bg-red-negative.text-white.w-full.sm_w-72 No Source Selected
+		button(v-if="source === ''" disabled).modal-button.bg-cupboard-dg.text-white.w-full.sm_w-72 No Source Selected
 		button(v-else @click="emit('accept', source)").modal-button.w-40.bg-utd-green.text-white
 			| Submit
 </template>

--- a/pages/inventory-management.vue
+++ b/pages/inventory-management.vue
@@ -43,7 +43,7 @@ div
 						)
 					// submit button
 					div.sticky.bottom-8.z-20.flex.justify-end.h-12.space-x-2
-						button(v-if="JSON.stringify(inventoryCountChanges) === '{}'" disabled).bg-red-negative.text-white.w-full.sm_w-72 No Changes
+						button(v-if="JSON.stringify(inventoryCountChanges) === '{}'" disabled).bg-cupboard-dg.text-white.w-full.sm_w-72 No Changes
 						button(v-else @click="currentModal = ModalType.REVIEW").bg-utd-green.text-white.w-full.sm_w-72 Review Changes
 						button(class="w-[50px]" @click="scrollToTop").bg-utd-green.text-white
 							ChevronUpIcon.m-auto.h-6.fill-white.stroke-white


### PR DESCRIPTION
A third button state that is not interact able has been added to the shopping cart viewer when there is no item in cart Edge case of item = 0, directly press button was tested and it should be fine

When cart has an item:
![image](https://github.com/user-attachments/assets/b2295fc1-d904-4375-bca3-f0170a50b133)

When cart does not:
![image](https://github.com/user-attachments/assets/65b49d0c-f5a3-4c48-98b5-bef228b12609)
